### PR TITLE
Inline functions refactor + documentation update

### DIFF
--- a/Fusion/FusionAhrs.c
+++ b/Fusion/FusionAhrs.c
@@ -113,7 +113,7 @@ void FusionAhrsInitialise(FusionAhrs * const fusionAhrs, const float gain, const
  * @param fusionAhrs Address of the FusionAhrs structure.
  * @param gyroscope Gyroscope measurement in degrees per second.
  * @param accelerometer Accelerometer measurement in g.
- * @param magnetometer Magnetometer measurement in any calibrated units.
+ * @param magnetometer Magnetometer measurement in uT.
  * @param samplePeriod Sample period in seconds.
  */
 void FusionAhrsUpdate(FusionAhrs * const fusionAhrs, const FusionVector3 gyroscope, const FusionVector3 accelerometer, const FusionVector3 magnetometer, const float samplePeriod) {

--- a/Fusion/FusionTypes.h
+++ b/Fusion/FusionTypes.h
@@ -171,11 +171,11 @@ static inline __attribute__((always_inline)) float FusionFastInverseSqrt(const f
  * @return Sum of vectorA and vectorB.
  */
 static inline __attribute__((always_inline)) FusionVector3 FusionVectorAdd(const FusionVector3 vectorA, const FusionVector3 vectorB) {
-    FusionVector3 result;
-    result.axis.x = vectorA.axis.x + vectorB.axis.x;
-    result.axis.y = vectorA.axis.y + vectorB.axis.y;
-    result.axis.z = vectorA.axis.z + vectorB.axis.z;
-    return result;
+    FusionVector3 resultAdd;
+    resultAdd.axis.x = vectorA.axis.x + vectorB.axis.x;
+    resultAdd.axis.y = vectorA.axis.y + vectorB.axis.y;
+    resultAdd.axis.z = vectorA.axis.z + vectorB.axis.z;
+    return resultAdd;
 }
 
 /**
@@ -185,11 +185,11 @@ static inline __attribute__((always_inline)) FusionVector3 FusionVectorAdd(const
  * @return vectorB subtracted from vectorA.
  */
 static inline __attribute__((always_inline)) FusionVector3 FusionVectorSubtract(const FusionVector3 vectorA, const FusionVector3 vectorB) {
-    FusionVector3 result;
-    result.axis.x = vectorA.axis.x - vectorB.axis.x;
-    result.axis.y = vectorA.axis.y - vectorB.axis.y;
-    result.axis.z = vectorA.axis.z - vectorB.axis.z;
-    return result;
+    FusionVector3 resultSubtract;
+    resultSubtract.axis.x = vectorA.axis.x - vectorB.axis.x;
+    resultSubtract.axis.y = vectorA.axis.y - vectorB.axis.y;
+    resultSubtract.axis.z = vectorA.axis.z - vectorB.axis.z;
+    return resultSubtract;
 }
 
 /**
@@ -199,11 +199,11 @@ static inline __attribute__((always_inline)) FusionVector3 FusionVectorSubtract(
  * @return Vector multiplied by scalar.
  */
 static inline __attribute__((always_inline)) FusionVector3 FusionVectorMultiplyScalar(const FusionVector3 vector, const float scalar) {
-    FusionVector3 result;
-    result.axis.x = vector.axis.x * scalar;
-    result.axis.y = vector.axis.y * scalar;
-    result.axis.z = vector.axis.z * scalar;
-    return result;
+    FusionVector3 resultMultiplyScalar;
+    resultMultiplyScalar.axis.x = vector.axis.x * scalar;
+    resultMultiplyScalar.axis.y = vector.axis.y * scalar;
+    resultMultiplyScalar.axis.z = vector.axis.z * scalar;
+    return resultMultiplyScalar;
 }
 
 /**
@@ -215,11 +215,11 @@ static inline __attribute__((always_inline)) FusionVector3 FusionVectorMultiplyS
 static inline __attribute__((always_inline)) FusionVector3 FusionVectorCrossProduct(const FusionVector3 vectorA, const FusionVector3 vectorB) {
 #define A vectorA.axis // define shorthand labels for more readable code
 #define B vectorB.axis
-    FusionVector3 result;
-    result.axis.x = A.y * B.z - A.z * B.y;
-    result.axis.y = A.z * B.x - A.x * B.z;
-    result.axis.z = A.x * B.y - A.y * B.x;
-    return result;
+    FusionVector3 resultCrossProduct;
+    resultCrossProduct.axis.x = A.y * B.z - A.z * B.y;
+    resultCrossProduct.axis.y = A.z * B.x - A.x * B.z;
+    resultCrossProduct.axis.z = A.x * B.y - A.y * B.x;
+    return resultCrossProduct;
 #undef A // undefine shorthand labels
 #undef B
 }


### PR DESCRIPTION
Having used the FusionVector*() functions in my code, I have experienced the following problem: if multiple inline functions are used nested in each other, the code fails because the temporary variables have the same name (my environment is: MPLAB X IDE, C30, PIC24F).
On the other hand, the comments for FusionAhrsUpdate are not 100% accurate, the magnetometer values should be in uT because this is the unit for the abandonment check.