### PR TITLE
Fix strict-aliasing violation (type punned pointers) in FusionFastInv…

### DIFF
--- a/Fusion/FusionTypes.h
+++ b/Fusion/FusionTypes.h
@@ -144,9 +144,9 @@ static inline __attribute__((always_inline)) float FusionRadiansToDegrees(const 
 static inline __attribute__((always_inline)) float FusionFastInverseSqrt(const float x) {
     float halfx = 0.5f * x;
     float y = x;
-    int32_t i = *(int32_t*) & y;
-    i = 0x5f3759df - (i >> 1);
-    y = *(float*) &i;
+    union { float f; int32_t i; } fi = { .f = y };
+    fi.i = 0x5f3759df - (fi.i >> 1);
+    y = fi.f;
     y = y * (1.5f - (halfx * y * y));
     return y;
 }


### PR DESCRIPTION
The current version of `FusionFastInverseSqrt()` violates the strict-aliasing rule [C11 Standard - §6.5 Expressions (p6,7)](http://port70.net/~nsz/c/c11/n1570.html#6.5p6) Fixed with `union` of `float` and `int32_t`.