### PR TITLE
#9 Fix inconsistency between quaternion and euler angle

### DIFF
--- a/Fusion/FusionAhrs.c
+++ b/Fusion/FusionAhrs.c
@@ -248,7 +248,7 @@ void FusionAhrsUpdateExternalHeading(FusionAhrs *const ahrs, const FusionVector 
  * @return Quaternion describing the sensor relative to the Earth.
  */
 FusionQuaternion FusionAhrsGetQuaternion(const FusionAhrs *const ahrs) {
-    return FusionQuaternionConjugate(ahrs->quaternion);
+    return ahrs->quaternion;
 }
 
 /**

--- a/Fusion/FusionMath.h
+++ b/Fusion/FusionMath.h
@@ -441,9 +441,9 @@ static inline FusionEuler FusionQuaternionToEuler(const FusionQuaternion quatern
 #define Q quaternion.element
     const float qwqwMinusHalf = Q.w * Q.w - 0.5f; // calculate common terms to avoid repeated operations
     FusionEuler euler;
-    euler.angle.roll = FusionRadiansToDegrees(atan2f(Q.y * Q.z - Q.w * Q.x, qwqwMinusHalf + Q.z * Q.z));
-    euler.angle.pitch = FusionRadiansToDegrees(-1.0f * asinf(2.0f * (Q.x * Q.z + Q.w * Q.y)));
-    euler.angle.yaw = FusionRadiansToDegrees(atan2f(Q.x * Q.y - Q.w * Q.z, qwqwMinusHalf + Q.x * Q.x));
+    euler.angle.roll = FusionRadiansToDegrees(-1.0f * atan2f(Q.y * Q.z - Q.w * Q.x, qwqwMinusHalf + Q.z * Q.z));
+    euler.angle.pitch = FusionRadiansToDegrees(asinf(2.0f * (Q.x * Q.z + Q.w * Q.y)));
+    euler.angle.yaw = FusionRadiansToDegrees(-1.0f * atan2f(Q.x * Q.y - Q.w * Q.z, qwqwMinusHalf + Q.x * Q.x));
     return euler;
 #undef Q
 }


### PR DESCRIPTION
According to https://quaternions.online/, convert quaternion wxyz{0.96,-0.009,-0.28,-0.024} to euler angle should be xyz{-2.085,-32.467,-3.471}. But `FusionQuaternionToEuler((FusionQuaternion){0.96,-0.009,-0.28,-0.024});` returns {2.084,32.491,3.469}, which every axis are reversed. 

After this commit, `FusionAhrsGetQuaternion()` will return unmodified quaternion, and `FusionQuaternionToEuler((FusionQuaternion){0.96,-0.009,-0.28,-0.024});` will return (FusionEuler){-2.0852904, -32.4671036, -3.4714111}.