### PR TITLE
Fix GCC compiler warnings

### DIFF
--- a/Fusion/FusionAhrs.c
+++ b/Fusion/FusionAhrs.c
@@ -241,6 +241,8 @@ static inline FusionVector HalfGravity(const FusionAhrs *const ahrs) {
             }}; // third column of transposed rotation matrix scaled by -0.5
             return halfGravity;
         }
+        default:
+            break;
     }
     return FUSION_VECTOR_ZERO; // avoid compiler warning
 #undef Q
@@ -278,6 +280,8 @@ static inline FusionVector HalfMagnetic(const FusionAhrs *const ahrs) {
             }}; // second column of transposed rotation matrix scaled by -0.5
             return halfMagnetic;
         }
+        default:
+            break;
     }
     return FUSION_VECTOR_ZERO; // avoid compiler warning
 #undef Q
@@ -404,6 +408,8 @@ FusionVector FusionAhrsGetLinearAcceleration(const FusionAhrs *const ahrs) {
         case FusionConventionNed: {
             return FusionVectorAdd(ahrs->accelerometer, gravity);
         }
+        default:
+            break;
     }
     return FUSION_VECTOR_ZERO; // avoid compiler warning
 #undef Q
@@ -441,6 +447,8 @@ FusionVector FusionAhrsGetEarthAcceleration(const FusionAhrs *const ahrs) {
             break;
         case FusionConventionNed:
             accelerometer.axis.z += 1.0f;
+            break;
+        default:
             break;
     }
     return accelerometer;

--- a/Fusion/FusionCompass.c
+++ b/Fusion/FusionCompass.c
@@ -41,6 +41,8 @@ float FusionCompassCalculateHeading(const FusionConvention convention, const Fus
             const FusionVector north = FusionVectorNormalise(FusionVectorCrossProduct(west, up));
             return FusionRadiansToDegrees(atan2f(west.axis.x, north.axis.x));
         }
+        default:
+            break;
     }
     return 0; // avoid compiler warning
 }


### PR DESCRIPTION
When using GCC with `-Wswitch-default` flag to compile the library, some switch statements generate a warning. This PR adds a `default` case for each warning. I believe this is also required by MISRA specification.

Alternatively, the `return FUSION_VECTOR_ZERO;` line could be put into the default case for `HalfGravity()`, `HalfMagnetic()` and `FusionAhrsGetLinearAcceleration()` functions. Same for `return 0;` in `FusionCompassCalculateHeading()`.