### PR TITLE
REV: fixed error in Quarternion.h in python, incorrect type for pytho…

### DIFF
--- a/Python/Python-C-API/Quaternion.h
+++ b/Python/Python-C-API/Quaternion.h
@@ -42,7 +42,7 @@ static PyObject *quaternion_get_wxyz(Quaternion *self) {
     const npy_intp dims[] = {4};
     PyObject* array = PyArray_SimpleNewFromData(1, dims, NPY_FLOAT, self->quaternion.array);
     Py_INCREF(self);
-    PyArray_SetBaseObject((PyArrayObject *) array, self);
+    PyArray_SetBaseObject((PyArrayObject *) array, (PyObject *) self);
     return array;
 }
 


### PR DESCRIPTION
…n dev libraries (expected it to be cast to PyObject* but it was returning type Quarternion*)