### PR TITLE
Compatibility with ESP-IDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,17 @@
 cmake_minimum_required(VERSION 3.15)
-project(Fusion)
 
-add_subdirectory("Fusion")
-add_subdirectory("Examples/Advanced")
-add_subdirectory("Examples/Simple")
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_subdirectory("Python/Python-C-API") # do not include when run by CI
+if (NOT ESP_PLATFORM)
+    project(Fusion)
+    add_subdirectory("Fusion")
+    add_subdirectory("Examples/Advanced")
+    add_subdirectory("Examples/Simple")
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_subdirectory("Python/Python-C-API") # do not include when run by CI
+    endif()
+else()
+    # ESP-IDF project
+    idf_component_register(
+        SRC_DIRS "Fusion"
+        INCLUDE_DIRS "Fusion"
+    )
 endif()

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,7 @@
+
+description:
+  Sensor fusion library for Inertial Measurement Units (IMUs)
+url: https://github.com/xioTechnologies/Fusion
+repository: https://github.com/xioTechnologies/Fusion
+issues: https://github.com/xioTechnologies/Fusion/issues
+


### PR DESCRIPTION
The addition of `idf_component.yml` and a minor change to the top-level `CMakeLists.txt` makes this library fully compatible with the ESP-IDF build system, which is the official vendor-provided development framework for the ESP32-family of microcontrollers.

The changes in this PR have no impact to other build systems.

Anyone who wishes to include the Fusion library in an embedded ESP-IDF project may do so by adding the following dependency to their project-specific IDF Component Manager Manifest file (`idf_component.yml`):
```
dependencies:
  Fusion:
    git: https://github.com/atfox98/Fusion # Or, if merged, this official repository
  ```

Further, this repository could be registered in the [ESP Component Registry](https://components.espressif.com/), which is a central place for ESP32 developers to find and include compatible libraries for their project (think of it like pypi for python or npm for javascript).

This PR is similar to #12 in that it provides compatibility for ESP-IDF, but it **should not** be thought of as project-specific PR. Rather, it should be thought of as a compatibility layer for a whole family of embedded devices, enabling easier inclusion and more widespread adoption of this fantastic technology.
