### PR TITLE
Small CMake  changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,14 @@
 cmake_minimum_required(VERSION 3.15)
 project(Fusion)
 
+option(FUSION_BUILD_EXAMPLES "Build examples" TRUE)
+option(FUSION_BUILD_PYTHON_API "Build Python C API" $<Config:Debug>)
+
 add_subdirectory("Fusion")
-add_subdirectory("Examples/Advanced")
-add_subdirectory("Examples/Simple")
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+if (FUSION_BUILD_EXAMPLES)
+    add_subdirectory("Examples/Advanced")
+    add_subdirectory("Examples/Simple")
+endif()
+if(FUSION_BUILD_PYTHON_API)
     add_subdirectory("Python/Python-C-API") # do not include when run by CI
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 project(Fusion)
 
 option(FUSION_BUILD_EXAMPLES "Build examples" TRUE)
-option(FUSION_BUILD_PYTHON_API "Build Python C API" $<Config:Debug>)
+option(FUSION_BUILD_PYTHON_API "Build Python C API" TRUE) 
 
 add_subdirectory("Fusion")
 if (FUSION_BUILD_EXAMPLES)

--- a/Examples/Advanced/main.c
+++ b/Examples/Advanced/main.c
@@ -1,4 +1,4 @@
-#include "../../Fusion/Fusion.h"
+#include "Fusion.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <time.h>

--- a/Examples/Simple/main.c
+++ b/Examples/Simple/main.c
@@ -1,4 +1,4 @@
-#include "../../Fusion/Fusion.h"
+#include "Fusion.h"
 #include <stdbool.h>
 #include <stdio.h>
 

--- a/Fusion/CMakeLists.txt
+++ b/Fusion/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB_RECURSE files "*.c")
 
 add_library(Fusion ${files})
+target_include_directories(Fusion PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(UNIX AND NOT APPLE)
     target_link_libraries(Fusion m) # link math library for Linux


### PR DESCRIPTION
Hi,
I recently integrated Fusion into one of my projects, and I found the CMake setup a bit lacking (even if the library is great! Thanks!)
The changes that I've made are in this PR. Hopefully this is useful to anyone.

In detail:

 - Added a 'FUSION_BUILD_EXAMPLES' CMake option. Defaults to 'TRUE'. Can be disabled on the command line via `-DFUSION_BUILD_EXAMPLES=FALSE` or in another CMakeLists file (before including Fusion) with `set(FUSION_BUILD_EXAMPLES FALSE)`
 - Added a 'FUSION_BUILD_PYTHON_API' CMake option. Defaults to 'TRUE'. Can be disabled the same ways as the examples option.
 - The 'Fusion' target now exports it's include directory to targets that user it (The examples have been updated accordingly)

I have not updated any of the action workflows (as I am not familiar with Python packaging), hopefully this doesn't break too many things there.