### PR TITLE
Update CMake scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,8 @@ jobs:
 
       - name: Build CMake targets
         run: |
-          mkdir cmake-build-release
-          cd cmake-build-release
-          cmake .. -DCMAKE_BUILD_TYPE=Release
-          cmake --build .
+          cmake -B cmake-build-release -S . -DCMAKE_BUILD_TYPE=Release
+          cmake --build cmake-build-release
 
   build_wheels:
     runs-on: ${{ matrix.target[0] }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
-project(Fusion)
+project(Fusion
+    VERSION 1.2.8
+    LANGUAGES C
+)
 
 add_subdirectory("Fusion")
 add_subdirectory("Examples/Advanced")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,13 @@ project(Fusion
     LANGUAGES C
 )
 
+option(BUILD_EXAMPLES "Build examples" ON)
+
 add_subdirectory("Fusion")
-add_subdirectory("Examples/Advanced")
-add_subdirectory("Examples/Simple")
+if(BUILD_EXAMPLES)
+    add_subdirectory("Examples/Advanced")
+    add_subdirectory("Examples/Simple")
+endif()
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_subdirectory("Python/Python-C-API") # do not include when run by CI
 endif()

--- a/Fusion/CMakeLists.txt
+++ b/Fusion/CMakeLists.txt
@@ -1,9 +1,72 @@
-file(GLOB_RECURSE files "*.c")
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
-add_library(Fusion ${files})
+set(FusionSources
+    FusionAhrs.c   FusionCompass.c
+    FusionOffset.c
+)
 
-target_include_directories(Fusion PUBLIC .)
+set(FusionHEADERS		
+    Fusion.h           FusionAxes.h
+    FusionCompass.h    FusionMath.h
+    FusionAhrs.h       FusionCalibration.h
+    FusionConvention.h FusionOffset.h
+)
+
+add_library(Fusion ${FusionSources})
+add_library(Fusion::lib ALIAS Fusion)
+
+target_include_directories(Fusion 
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/Fusion>
+)
 
 if(UNIX AND NOT APPLE)
     target_link_libraries(Fusion m) # link math library for Linux
 endif()
+
+set_target_properties(Fusion
+    PROPERTIES
+        PUBLIC_HEADER "${FusionHEADERS}"
+        EXPORT_NAME lib
+)
+
+export(TARGETS Fusion
+    NAMESPACE Fusion::
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/FusionTargets.cmake
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(FusionConfig.cmake.in 
+  ${CMAKE_CURRENT_BINARY_DIR}/FusionConfig.cmake
+  NO_SET_AND_CHECK_MACRO
+  PATH_VARS CMAKE_INSTALL_PREFIX
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Fusion"
+)
+
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/FusionConfigVersion.cmake"
+  COMPATIBILITY AnyNewerVersion
+)
+
+install(TARGETS Fusion
+    EXPORT FusionTargets
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Fusion
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Fusion
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(EXPORT FusionTargets
+    FILE "FusionTargets.cmake"
+    NAMESPACE Fusion::
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Fusion"
+)
+
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/FusionConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/FusionConfigVersion.cmake
+    DESTINATION 
+        ${CMAKE_INSTALL_LIBDIR}/cmake/Fusion
+)

--- a/Fusion/FusionConfig.cmake.in
+++ b/Fusion/FusionConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/FusionTargets.cmake" )
+
+check_required_components(Fusion)


### PR DESCRIPTION
Hello,

This PR updates the CMake scripts with the following:
- Add a new configuration option (`BUILD_EXAMPLES`) to enable or disable the build of examples (enabled by default).
- Add install target that will install the library, header files and CMake configuration scripts.
- Update the Fusion target in order to propagate the library include directories when used both with `add_subdirectory` and as an external package.

For example, the following commands will build the library without the examples and install it.
```
cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${HOME}/packages -DBUILD_EXAMPLES=OFF
cmake --build ./build --target install 
```

After this `${HOME}/packages` will contain:
```
${HOME}/packages
├── include
│   └── Fusion
│       ├── Fusion.h
│       ├── FusionAhrs.h
│       ├── FusionAxes.h
│       ├── FusionCalibration.h
│       ├── FusionCompass.h
│       ├── FusionConvention.h
│       ├── FusionMath.h
│       └── FusionOffset.h
└── lib
    ├── cmake
    │   └── Fusion
    │       ├── FusionConfig.cmake
    │       ├── FusionConfigVersion.cmake
    │       ├── FusionTargets-release.cmake
    │       └── FusionTargets.cmake
    └── libFusion.a
```

This way projects can use the Fusion library by passing `-DFusion_DIR=${HOME}/packages/lib/cmake/Fusion` during project configuration, using `find_package(Fusion)` in the CMake script and link with `Fusion::lib`.
```cmake
find_package(Fusion 1.2.8 REQUIRED)

add_executable(foo foo.c)
target_link_libraries(foo Fusion::lib) 
```
