### PR TITLE
install and export CMake targets and headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(Fusion)
 
+include(GNUInstallDirs)
+
 add_subdirectory("Fusion")
 add_subdirectory("Examples/C/Advanced")
 add_subdirectory("Examples/C/Simple")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
 project(Fusion)
 
+include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
+
 
 add_subdirectory("Fusion")
 add_subdirectory("Examples/C/Advanced")
@@ -9,3 +11,14 @@ add_subdirectory("Examples/C/Simple")
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_subdirectory("Python/imufusion") # do not include when run by CI
 endif()
+
+configure_package_config_file(
+    cmake/FusionConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/FusionConfig.cmake
+    INSTALL_DESTINATION cmake/
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    DESTINATION cmake/
+)

--- a/Fusion/CMakeLists.txt
+++ b/Fusion/CMakeLists.txt
@@ -10,6 +10,9 @@ target_include_directories(Fusion PUBLIC
 
 set_property(TARGET Fusion PROPERTY CXX_STANDARD 20)
 
+set_property(TARGET Fusion PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+
+
 if(UNIX AND NOT APPLE)
     target_link_libraries(Fusion m) # link math library for Linux
 endif()

--- a/Fusion/CMakeLists.txt
+++ b/Fusion/CMakeLists.txt
@@ -25,3 +25,8 @@ install(FILES
     ${header}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/
 )
+
+install(EXPORT FusionTargets
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION cmake/
+)

--- a/Fusion/CMakeLists.txt
+++ b/Fusion/CMakeLists.txt
@@ -1,9 +1,22 @@
 file(GLOB_RECURSE files "*.c")
+file(GLOB_RECURSE header "*.h")
 
 add_library(Fusion ${files})
 
-target_include_directories(Fusion PUBLIC .)
+target_include_directories(Fusion PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include/>
+)
 
 if(UNIX AND NOT APPLE)
     target_link_libraries(Fusion m) # link math library for Linux
 endif()
+
+install(TARGETS Fusion
+    EXPORT FusionTargets
+)
+
+install(FILES
+    ${header}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/
+)

--- a/Fusion/CMakeLists.txt
+++ b/Fusion/CMakeLists.txt
@@ -8,6 +8,8 @@ target_include_directories(Fusion PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include/>
 )
 
+set_property(TARGET Fusion PROPERTY CXX_STANDARD 20)
+
 if(UNIX AND NOT APPLE)
     target_link_libraries(Fusion m) # link math library for Linux
 endif()

--- a/cmake/FusionConfig.cmake.in
+++ b/cmake/FusionConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/FusionTargets.cmake")

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>fusion</name>
+  <version>1.2.11</version>
+  <description>Fusion is a sensor fusion library for Inertial Measurement Units (IMUs), optimised for embedded systems.</description>
+  <maintainer email="info@x-io.co.uk">x-io Technologies Limited</maintainer>
+  <license>MIT</license>
+  <url>https://github.com/xioTechnologies/Fusion</url>
+  <author>Seb Madgwick</author>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This allows finding the library with:
```cmake
find_package(Fusion REQUIRED)
```
and using its targets with:
```cmake
target_link_libraries(my_project PUBLIC
  Fusion::Fusion
)
```

This automatically links the library and sets the include paths.

This includes https://github.com/xioTechnologies/Fusion/pull/289.