### PR TITLE
install library and header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(Fusion)
 
+include(GNUInstallDirs)
+
 add_subdirectory("Fusion")
 add_subdirectory("Examples/C/Advanced")
 add_subdirectory("Examples/C/Simple")

--- a/Fusion/CMakeLists.txt
+++ b/Fusion/CMakeLists.txt
@@ -8,6 +8,8 @@ target_include_directories(Fusion PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include/>
 )
 
+set_property(TARGET Fusion PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+
 if(UNIX AND NOT APPLE)
     target_link_libraries(Fusion m) # link math library for Linux
 endif()

--- a/Fusion/CMakeLists.txt
+++ b/Fusion/CMakeLists.txt
@@ -1,9 +1,22 @@
 file(GLOB_RECURSE files "*.c")
+file(GLOB_RECURSE header "*.h")
 
 add_library(Fusion ${files})
 
-target_include_directories(Fusion PUBLIC .)
+target_include_directories(Fusion PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include/>
+)
 
 if(UNIX AND NOT APPLE)
     target_link_libraries(Fusion m) # link math library for Linux
 endif()
+
+install(TARGETS Fusion
+    EXPORT FusionTargets
+)
+
+install(FILES
+    ${header}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/
+)


### PR DESCRIPTION
This extends the CMake instructions to install the library and header files for Fusion. It also sets enables PIC..

The definition of the `BUILD_INTERFACE` and `INSTALL_INTERFACE` in `target_include_directories` fixes issues such as:
```
CMake Error in [...]/_deps/madgwick_fusion-src/Fusion/CMakeLists.txt:
  Target "Fusion" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "[...]/_deps/madgwick_fusion-src/Fusion/."

  which is prefixed in the build directory.
```
when the repo is used via CMake's `FetchContent`.

Enabling PIC fixes issues such as:
```
/usr/bin/ld: ../_deps/madgwick_fusion-build/Fusion/libFusion.a(FusionAhrs.c.o): warning: relocation against `fusionAhrsDefaultSettings' in read-only section `.text'
/usr/bin/ld: ../_deps/madgwick_fusion-build/Fusion/libFusion.a(FusionAhrs.c.o): relocation R_X86_64_PC32 against symbol `fusionAhrsDefaultSettings' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
```
